### PR TITLE
Update filters interface and useHelpers to change 'contains' to 'cont…

### DIFF
--- a/src/interfaces/filters.ts
+++ b/src/interfaces/filters.ts
@@ -5,7 +5,7 @@ export interface IFilters {
 
 export interface IGraphQLFilters {
   name?: {
-    contains: string | null;
+    containsi: string | null;
   };
   location?: {
     city?: {

--- a/src/modules/useHelpers.ts
+++ b/src/modules/useHelpers.ts
@@ -5,7 +5,7 @@ const useHelpers = () => {
     return {
       ...(filters.name && {
         name: {
-          contains: filters.name || null,
+          containsi: filters.name || null,
         },
       }),
       ...(filters.city && {


### PR DESCRIPTION
…ainsi'

- Modified IGraphQLFilters interface to rename 'contains' property to 'containsi' for consistency.
- Updated useHelpers function to reflect the change in property name when constructing filter objects.