### PR TITLE
KAN-43 Implement scroll position management in router

### DIFF
--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -14,7 +14,7 @@ const routes: RouteRecordRaw[] = [
       {
         path: '',
         component: () => import('pages/IndexPage.vue'),
-        meta: { title: 'Search Page' },
+        meta: { title: 'Search Page', saveScrollPosition: true },
       },
       {
         path: 'bookmarks',

--- a/src/stores/scroll.ts
+++ b/src/stores/scroll.ts
@@ -1,0 +1,16 @@
+import { defineStore } from 'pinia';
+
+export const useScrollStore = defineStore('scroll', {
+  state: () => ({
+    scrollPositions: {},
+  }),
+  getters: {
+    getScrollPositions: (state) => state.scrollPositions,
+    getScrollPosition: (state) => (path: string) => state.scrollPositions[path as keyof typeof state.scrollPositions],
+  },
+  actions: {
+    setScrollPosition(path: string, position: number) {
+      this.scrollPositions = { ...this.scrollPositions, [path]: position };
+    },
+  },
+});


### PR DESCRIPTION
- Added a scroll store to manage scroll positions across routes.
- Updated router to save and restore scroll positions based on route metadata.
- Modified routes to include 'saveScrollPosition' meta property for relevant pages.